### PR TITLE
fail gracefully if no face have been seen during view selection

### DIFF
--- a/libs/tex/global_seam_leveling.cpp
+++ b/libs/tex/global_seam_leveling.cpp
@@ -175,6 +175,10 @@ global_seam_leveling(UniGraph const & graph, mve::TriangleMesh::ConstPtr mesh,
     }
     std::size_t x_rows = x_row;
     assert(x_rows < static_cast<std::size_t>(std::numeric_limits<int>::max()));
+    if (x_rows == 0) {
+        std::cout << "no labeled face found. abort global seaming." << std::endl;
+        return;
+    }
 
     float const lambda = 0.1f;
 

--- a/libs/tex/view_selection.cpp
+++ b/libs/tex/view_selection.cpp
@@ -263,6 +263,9 @@ view_selection(DataCosts const & data_costs, UniGraph * graph, Segmentation cons
         if (label == 0) undefined += 1;
         graph->set_label(i, static_cast<std::size_t>(label));
     }
+    if (undefined > 1 && undefined == num_faces) {
+        throw std::runtime_error("None of the faces have been seen. Are they inverted?");
+    }
     std::cout << '\t' << undefined << " faces have not been seen" << std::endl;
 }
 


### PR DESCRIPTION
otherwise the global seam leveling crashed with segfault.